### PR TITLE
Wrapped all bridge communication in try blocks and bubbled error event

### DIFF
--- a/lib/uvm/bridge.js
+++ b/lib/uvm/bridge.js
@@ -27,10 +27,12 @@ var vm = require('vm'),
     }(JSON.parse));
 
 /**
+ * This function equips an event emitter with communication capability with a VM.
+ *
  * @param  {EventEmitter} emitter
  * @param  {Object} options
  * @param  {String} options.bootcode
- * @param  {vm~Context} options._sandbox
+ * @param  {vm~Context=} [options._sandbox]
  * @param  {Function} callback
  */
 module.exports = function (emitter, options, callback) {
@@ -66,13 +68,9 @@ module.exports = function (emitter, options, callback) {
 
     // since context is created and emitter is bound, we would now attach the send function
     emitter._dispatch = function () {
-        try {
-            bridgeDispatch(jsonArray(arguments));
-        }
+        try { bridgeDispatch(jsonArray(arguments)); }
         // swallow errors since other platforms will not trigger error if execution fails
-        catch (e) {
-            this.emit('error', e);
-        }
+        catch (e) { this.emit(ERROR, e); }
     };
 
     emitter._disconnect = function () {

--- a/lib/uvm/index.js
+++ b/lib/uvm/index.js
@@ -3,22 +3,42 @@ var _ = require('lodash'),
     EventEmitter = require('events'),
     bridge = require('./bridge'),
 
+    ERROR_EVENT = 'error',
+    DISPATCHQUEUE_EVENT = 'dispatchQueued',
+    DISCONNECT_ERROR_MESSAGE = 'uvm: cannot disconnect, communication bridge is broken',
+
     UniversalVM;
 
 /**
  * @constructor
  * @extends {EventEmitter}
  * @param {Object} options
+ * @param {String} options.bootcode
  * @param {Function} callback
  */
 UniversalVM = function UniversalVM (options, callback) {
-
     // set defaults for parameters
     !_.isObject(options) && (options = {});
-    !_.isFunction(callback) && (callback = _.noop);
 
     // call the super constructor
     EventEmitter.call(this);
+
+    /**
+     * Wrap the callback for unified result and reduce chance of bug.
+     * We also abandon all dispatch replay
+     * @param  {Error=} [err]
+     */
+    var done = function (err) {
+        if (err) {
+            this._pending.length = 0;
+
+            try { this.emit(ERROR_EVENT, err); }
+            // nothing to do if listeners fail, we need to move on and execute callback!
+            catch (e) { } // eslint-disable-line no-empty
+        }
+
+        _.isFunction(callback) && callback.call(this, err, this);
+    }.bind(this);
 
     /**
      * Stores the pending dispatch events until the context is ready for use. Useful when not using the asynchronous
@@ -34,14 +54,25 @@ UniversalVM = function UniversalVM (options, callback) {
 
     // we bridge this event emitter with the context (bridge usually creates the context as well)
     bridge(this, _.defaults(options, {}), function (err) {
-        var args;
-
-        // we dispatch all pending messages provided nothing had errors
-        while ((args = this._pending.shift())) {
-            this.dispatch.apply(this, args);
+        // on error during bridging, we simply abandon all dispatch replay and bail out through callback
+        if (err) {
+            this._pending.length = 0;
+            return done(err);
         }
 
-        callback(err, this);
+        var args;
+
+        try {
+            // we dispatch all pending messages provided nothing had errors
+            while ((args = this._pending.shift())) {
+                this.dispatch.apply(this, args);
+            }
+        }
+        // since there us no further work after dispatching events, we re-use the err parameter.
+        // at this point err variable is falsey since truthy case is already handled before
+        catch (e) { err = e; }
+
+        done(err);
     }.bind(this));
 };
 
@@ -50,20 +81,22 @@ inherits(UniversalVM, EventEmitter);
 
 _.assign(UniversalVM.prototype, {
     dispatch: function () {
-        this._dispatch.apply(this, arguments);
+        try { this._dispatch.apply(this, arguments); }
+        catch (e) { this.emit(ERROR_EVENT, e); }
     },
 
     disconnect: function () {
-        this._disconnect.apply(this, arguments);
+        try { this._disconnect.apply(this, arguments); }
+        catch (e) { this.emit(ERROR_EVENT, e); }
     },
 
-    _dispatch: function () {
-        this.emit('dispatchQueued');
+    _dispatch: function (name) {
+        this.emit(DISPATCHQUEUE_EVENT, name);
         this._pending.push(arguments);
     },
 
     _disconnect: function () {
-        throw new Error('uvm: cannot disconnect, communication bridge is broken');
+        throw new Error(DISCONNECT_ERROR_MESSAGE);
     }
 });
 

--- a/lib/uvm/index.js
+++ b/lib/uvm/index.js
@@ -47,8 +47,6 @@ UniversalVM = function UniversalVM (options, callback) {
      * @private
      * @memberOf UniversalVM.prototype
      * @type {Array}
-     *
-     * @todo clear wasted pending messages post context initialization error
      */
     this._pending = [];
 
@@ -56,7 +54,7 @@ UniversalVM = function UniversalVM (options, callback) {
     bridge(this, _.defaults(options, {}), function (err) {
         // on error during bridging, we simply abandon all dispatch replay and bail out through callback
         if (err) {
-            this._pending.length = 0;
+            this._pending && (this._pending.length = 0);
             return done(err);
         }
 
@@ -79,28 +77,56 @@ UniversalVM = function UniversalVM (options, callback) {
 // make UVM inherit from event emitter
 inherits(UniversalVM, EventEmitter);
 
-_.assign(UniversalVM.prototype, {
+// equip the event emitter with an interface to communicate with the other end of the bridge
+_.assign(UniversalVM.prototype, /** @lends UVM.prototype */ {
+    /**
+     * Emit an event on the other end of bridge. The parameters are same as `emit` function of the event emitter.
+     */
     dispatch: function () {
         try { this._dispatch.apply(this, arguments); }
         catch (e) { this.emit(ERROR_EVENT, e); }
     },
 
+    /**
+     * Disconnect the bridge and release memory.
+     */
     disconnect: function () {
         try { this._disconnect.apply(this, arguments); }
         catch (e) { this.emit(ERROR_EVENT, e); }
     },
 
+    /**
+     * Stub dispatch handler to queue dispatched messages until bridge is ready.
+     * @param {String} name
+     */
     _dispatch: function (name) {
+        (Array.isArray(this._pending) ? this._pending : (this._pending = [])).push(arguments);
         this.emit(DISPATCHQUEUE_EVENT, name);
-        this._pending.push(arguments);
     },
 
+    /**
+     * The bridge should be ready to disconnect when this is called. If not, then this prototype stub would throw an
+     * error
+     *
+     * @throws {Error} If bridge is not ready and this function is called.
+     */
     _disconnect: function () {
         throw new Error(DISCONNECT_ERROR_MESSAGE);
     }
 });
 
+// add some handy static functions
 _.assign(UniversalVM, {
+    /**
+     * Creates a new instance of UVM. This is merely an alias of the {@link UVM} construction creation without needing
+     * to write the `new` keyword.
+     *
+     * @param {Object} options
+     * @param {Function} callback
+     * @returns UVM
+     *
+     * @see UVM
+     */
     spawn: function (options, callback) {
         return new UniversalVM(options, callback);
     }

--- a/test/unit/uvm-errors.test.js
+++ b/test/unit/uvm-errors.test.js
@@ -1,0 +1,45 @@
+describe('uvm errors', function () {
+    var uvm = require('../../lib');
+
+    it('must raise an error if sandbox disconnect is somehow broken', function (done) {
+        var context = uvm.spawn();
+
+        // delete context._disconnect to further sabotage the bridge
+        delete context._disconnect;
+
+        context.on('error', function (err) {
+            expect(err).be.ok();
+            expect(err).to.have.property('message', 'uvm: cannot disconnect, communication bridge is broken');
+            done();
+        });
+
+        context.disconnect(null);
+    });
+
+    // @todo find a way to fix this
+    it('must fail to dispatch cyclic object', function (done) {
+        var context = uvm.spawn({
+                bootcode: `
+                    bridge.on('loopback', function (data) {
+                        bridge.dispatch('loopback', data);
+                    });
+                `
+            }),
+
+            cyclic,
+            subcycle;
+
+        context.on('error', function (err) {
+            expect(err).be.ok();
+            expect(err).to.have.property('name', 'TypeError');
+            expect(err).to.have.property('message', 'Converting circular structure to JSON');
+            done();
+        });
+
+        cyclic = {};
+        subcycle = {c1: cyclic};
+        cyclic.c2 = subcycle;
+
+        context.dispatch('loopback', cyclic);
+    });
+});

--- a/test/unit/uvm-sanity.test.js
+++ b/test/unit/uvm-sanity.test.js
@@ -1,5 +1,5 @@
 describe('uvm', function () {
-    var uvm = require('../../lib/uvm');
+    var uvm = require('../../lib');
 
     it('must connect a new context', function (done) {
         uvm.spawn({}, done);
@@ -22,7 +22,6 @@ describe('uvm', function () {
 
         it('must allow dispatching events to context', function () {
             var context = uvm.spawn();
-
 
             context.dispatch();
             context.dispatch('event-name');


### PR DESCRIPTION
The process of bridging itself is not wrapped since it is such a fatal error that things should crash and not be handled as callback. However, if we were to handle it in callback, there is little guarantee that it will be a synchronous error and the effort will go in vain.