### PR TITLE
finalising browser external sandbox

### DIFF
--- a/firmware/sandbox-base.js
+++ b/firmware/sandbox-base.js
@@ -1,0 +1,13 @@
+module.exports = `
+<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+<meta charset="UTF-8"><script type="text/javascript">
+(function (win) {
+    var init = function (e) {
+        win.removeEventListener('message', init);
+        // eslint-disable-next-line no-eval
+        (e && e.data && (typeof e.data.__init_uvm === 'string')) && eval(e.data.__init_uvm);
+    };
+    win.addEventListener('message', init);
+}(window));
+</script>
+</head></html>`;

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -30,21 +30,25 @@ var _ = require('lodash'),
      * @param  {String} code
      * @return {String}
      */
-    sandboxCode = function (code, id) {
-        return `<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-            <meta charset="UTF-8">
-            <script type="text/javascript">
+    sandboxCode = function (code, id, firmwareOnly) {
+        var firmware = `
             __uvm_emit = function (args) {window.parent.postMessage({__id_uvm: "${id}",__emit_uvm: args}, "*");};
-            </script>
-            <script type="text/javascript">${code}</script>
-            <script type="text/javascript">(function (emit, id) {
+
+            try {${code}} catch (e) { setTimeout(function () { throw e; }, 0); }
+
+            (function (emit, id) {
                 window.addEventListener("message", function (e) {
                     (e && e.data && (typeof e.data.__emit_uvm === 'string') && (e.data.__id_uvm === id)) &&
                         emit(e.data.__emit_uvm);
                 });
             }(__uvm_dispatch, "${id}"));
-            __uvm_dispatch = null; __uvm_emit = null;</script>
-            </head></html>`;
+            __uvm_emit('["load.${id}"]');
+            __uvm_dispatch = null; __uvm_emit = null;
+        `;
+
+        return firmwareOnly ? firmware : `<!DOCTYPE html><html><head>
+            <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"><meta charset="UTF-8">
+            <script type="text/javascript">${firmware}</script></head></html>`;
     };
 
 module.exports = function (bridge, options, callback) {

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -67,7 +67,7 @@ module.exports = function (bridge, options, callback) {
         },
 
         processCallback = function () {
-            iframe.removeEventListener(LOAD, processCallback);
+            !options._sandbox && iframe.removeEventListener(LOAD, processCallback);
 
             bridge._dispatch = function () {
                 iframe && iframe.contentWindow.postMessage({
@@ -81,6 +81,31 @@ module.exports = function (bridge, options, callback) {
 
     // add event listener for receiving events from iframe (is removed on disconnect)
     window.addEventListener(MESSAGE, forwardEmits);
+
+    // equip bridge to disconnect (i.e. delete the iframe)
+    bridge._disconnect = function () {
+        if (!iframe) { return; }
+
+        // remove the message handler for this sandbox
+        window.removeEventListener(MESSAGE, forwardEmits);
+
+        // do not delete sandbox element if not created for the bridge
+        !options._sandbox && iframe.parentNode && iframe.parentNode.removeChild(iframe);
+        iframe = null;
+    };
+
+    // if sandbox element is provided, we simply need to init with firmware code and wait for load event to be fired
+    if (options._sandbox) {
+        bridge.once('load.' + id, processCallback); // on load attach the dispatcher
+
+        iframe.contentWindow.postMessage({
+            __init_uvm: sandboxCode(code, id, true) // the last `true` param indicates firmwareOnly
+        }, TARGET_ALL);
+
+        return;
+    }
+
+    // this point onwards, it is our own iframe, so we do all the appending and other stuff to DOM
     iframe.addEventListener(LOAD, processCallback); // removed right when executed
 
     // prepare an iframe as context
@@ -90,17 +115,6 @@ module.exports = function (bridge, options, callback) {
 
     // add HTML and bootstrap code to the iframe
     iframe.setAttribute('src', 'data:text/html;base64, ' + btoa(unescape(encodeURIComponent(sandboxCode(code, id)))));
-
-    // equip bridge to disconnect (i.e. delete the iframe)
-    bridge._disconnect = function () {
-        if (!iframe) { return; }
-
-        window.removeEventListener(MESSAGE, forwardEmits);
-
-        // do not delete sandbox element if not created for the bridge
-        !options._sandbox && iframe.parentNode && iframe.parentNode.removeChild(iframe);
-        iframe = null;
-    };
 
     // now append the iframe to start processing stuff
     document.body.appendChild(iframe);

--- a/test/unit/uvm-browser-custom-sandbox.test.js
+++ b/test/unit/uvm-browser-custom-sandbox.test.js
@@ -1,0 +1,40 @@
+(typeof window !== 'undefined' ? describe : describe.skip)('custom iframe in browser', function () {
+    var uvm = require('../../lib'),
+        firmware = require('../../firmware/sandbox-base'),
+        iframe;
+
+    beforeEach(function (done) {
+        iframe = document.createElement('iframe');
+        iframe.setAttribute('src', 'data:text/html;base64, ' +
+            btoa(unescape(encodeURIComponent(firmware))));
+        iframe.addEventListener('load', function () {
+            done();
+        });
+        document.body.appendChild(iframe);
+    });
+
+    it('must load and dispatch messages', function (done) {
+        uvm.spawn({
+            _sandbox: iframe,
+            bootCode: `
+                bridge.on('loopback', function (data) {
+                    bridge.dispatch('loopback', data);
+                });
+            `
+        }, function (err, context) {
+            if (err) { return done(err); }
+
+            context.on('loopback', function (data) {
+                expect(data).be('this should return');
+                done();
+            });
+            context.dispatch('loopback', 'this should return');
+        });
+
+    });
+
+    afterEach(function () {
+        iframe.parentNode.removeChild(iframe);
+        iframe = null;
+    });
+});


### PR DESCRIPTION
This PR allows one to pass an existing iframe in browser variant of UVM via the `_sandbox` option.
The firmware HTML needed for this iframe is available at `require('uvm/firmware/sandbox-base');`

There are tests that uses this.