### PR TITLE
Fixed an issue where post disposal dispatch always raises an error event

### DIFF
--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -70,7 +70,12 @@ module.exports = function (bridge, options, callback) {
             !options._sandbox && iframe.removeEventListener(LOAD, processCallback);
 
             bridge._dispatch = function () {
-                iframe && iframe.contentWindow.postMessage({
+                if (!iframe) {
+                    return bridge.emit(ERROR,
+                        new Error('uvm: unable to dispatch "' + arguments[0] + '" post disconnection.'));
+                }
+
+                iframe.contentWindow.postMessage({
                     __emit_uvm: CircularJSON.stringify(Array.prototype.slice.call(arguments)),
                     __id_uvm: id
                 }, TARGET_ALL);

--- a/lib/uvm/bridge.js
+++ b/lib/uvm/bridge.js
@@ -97,6 +97,11 @@ module.exports = function (emitter, options, callback) {
         var id = UVM_DATA_ + randomNumber(),
             dispatchId = UVM_DISPATCH_ + id;
 
+        // trigger event if any dispatch happens post disconnection
+        if (!context) {
+            return this.emit(ERROR, new Error(`uvm: unable to dispatch "${arguments[0]}" post disconnection.`));
+        }
+
         try {
             // save the data in context. by this method, we avoid needless string and character encoding or escaping
             // issues. this is slightly prone to race condition issues, but using random numbers we intend to solve it
@@ -118,8 +123,10 @@ module.exports = function (emitter, options, callback) {
         // swallow errors since other platforms will not trigger error if execution fails
         catch (e) { this.emit(ERROR, e); }
         finally { // precautionary delete
-            delete context[id];
-            delete context[dispatchId];
+            if (context) {
+                delete context[id];
+                delete context[dispatchId];
+            }
         }
     };
 

--- a/test/unit/uvm-sanity.test.js
+++ b/test/unit/uvm-sanity.test.js
@@ -113,5 +113,30 @@ describe('uvm', function () {
                 context.dispatch('loopback', 'this returns');
             });
         });
+
+        it('must trigger error if dispatched post disconnection', function (done) {
+            uvm.spawn({
+                bootCode: `
+                    bridge.on('loopback', function (data) {
+                        bridge.dispatch('loopback', data);
+                    });
+                `
+            }, function (err, context) {
+                expect(err).not.be.an('object');
+
+                context.on('error', function (err) {
+                    expect(err).be.ok();
+                    expect(err).have.property('message', 'uvm: unable to dispatch "loopback" post disconnection.');
+                    done();
+                });
+
+                context.on('loopback', function () {
+                    throw new Error('loopback callback was unexpected post disconnection');
+                });
+
+                context.disconnect();
+                context.dispatch('loopback', 'this never returns');
+            });
+        });
     });
 });


### PR DESCRIPTION
This PR ensures that any erroneous dispatch called post disconnection is gracefully handled as an error event instead of throwing error.