### PR TITLE
Feature/allow client bridge to remove all events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Postman UVM Changelog
 
+#### Unreleased
+* add ability to remove all events when only event name is provided to `bridge.off`
+
 #### 1.6.0 (May 30, 2017)
 * add support for removal of bridge events (internal) using `bridge.off`
 

--- a/lib/uvm/bridge-client.js
+++ b/lib/uvm/bridge-client.js
@@ -43,9 +43,13 @@ module.exports = function (bootCode) {
 
         off: function (name, listener) {
             var e = this._events[name],
-                i = e && this._events[name].length;
+                i = e && e.length || 0;
 
             if (!e) { return; }
+            if (arguments.length === 1) {
+                return delete this._events[name];
+            }
+
             if (typeof listener === 'function' && (i >= 1)) {
                 while (i >= 0) {
                     (e[i] === listener) && e.splice(i, 1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uvm",
-  "version": "1.6.0",
+  "version": "1.6.1-beta.1",
   "description": "Universal Virtual Machine for Node and Browser",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
This will provide support for `bridge.off('event_name');` to remove all listeners under `event_name`. this will be useful in clearing events from outside UVM using dispatch and not worrying about keeping actual references to the subscribers