### PR TITLE
Update jsdoc-to-markdown to version 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "expect.js": "0.3.1",
     "js-yaml": "3.10.0",
     "jsdoc": "3.5.5",
-    "jsdoc-to-markdown": "3.0.0",
+    "jsdoc-to-markdown": "3.0.2",
     "karma": "1.7.1",
     "karma-browserify": "5.1.2",
     "karma-chrome-launcher": "2.2.0",


### PR DESCRIPTION
Closes #117