### PR TITLE
Use `srcdoc` attribute on `iframe` for loading bootcode in browser sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Postman UVM Changelog
 
+### Unreleased
+* use `srcdoc` attribute in `iframe`, when available, for loading sandbox code browser environments
+
 #### 1.7.0 (May 31, 3017)
 * removed dispatch of `disconnect` event when .disconnect() is called
 * add ability to remove all events when only event name is provided to `bridge.off`

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -124,6 +124,11 @@ module.exports = function (bridge, options, callback) {
     // add HTML and bootstrap code to the iframe
     iframe.setAttribute('src', 'data:text/html;base64, ' + btoa(unescape(encodeURIComponent(sandboxCode(code, id)))));
 
+    // data uri has size limits depending on the browsers
+    // in browsers that don't support srcdoc attribute the src attribute is accepted
+    // https://www.w3.org/TR/html5/semantics-embedded-content.html#an-iframe-srcdoc-document
+    iframe.setAttribute('srcdoc', unescape(encodeURIComponent(sandboxCode(code, id))));
+
     // now append the iframe to start processing stuff
     document.body.appendChild(iframe);
 };

--- a/test/unit/uvm-browser-large-firmware.test.js
+++ b/test/unit/uvm-browser-large-firmware.test.js
@@ -1,0 +1,74 @@
+(typeof window !== 'undefined' ? describe : describe.skip)('custom iframe in browser', function () {
+    var _ = require('lodash'),
+        uvm = require('../../lib'),
+
+        /**
+         * Creates a large string with a given character length.
+         *
+         * @param {Number} size
+         *
+         * @returns {String}
+         */
+        getLargeString = function (size) {
+            return _.pad('', size, 'a');
+        },
+        getFirmware = function (code) {
+            return `
+            <!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+            <meta charset="UTF-8">
+            <script type="text/javascript">
+            ${code}
+            </script>
+            <script type="text/javascript">
+            (function (win) {
+                var init = function (e) {
+                    win.removeEventListener('message', init);
+                    // eslint-disable-next-line no-eval
+                    (e && e.data && (typeof e.data.__init_uvm === 'string')) && eval(e.data.__init_uvm);
+                };
+                win.addEventListener('message', init);
+            }(window));
+            </script>
+            </head></html>`;
+        },
+        iframe;
+
+    beforeEach(function (done) {
+        var fakeBundleSize = 5 * 1024 * 1024, // 10mb (5 million characters with 2 bytes each)
+            largeJSStatement = `var x = '${getLargeString(fakeBundleSize)}';`;
+
+        iframe = document.createElement('iframe');
+        iframe.setAttribute('src', 'data:text/html;base64, ' +
+            btoa(unescape(encodeURIComponent(getFirmware(largeJSStatement)))));
+        iframe.setAttribute('srcdoc', unescape(encodeURIComponent(getFirmware(largeJSStatement))));
+        iframe.addEventListener('load', function () {
+            done();
+        });
+        document.body.appendChild(iframe);
+    });
+
+    it('must load and dispatch messages', function (done) {
+        uvm.spawn({
+            _sandbox: iframe,
+            bootCode: `
+                bridge.on('loopback', function (data) {
+                    bridge.dispatch('loopback', data);
+                });
+            `
+        }, function (err, context) {
+            if (err) { return done(err); }
+
+            context.on('loopback', function (data) {
+                expect(data).be('this should return');
+                done();
+            });
+            context.dispatch('loopback', 'this should return');
+        });
+
+    });
+
+    afterEach(function () {
+        iframe.parentNode.removeChild(iframe);
+        iframe = null;
+    });
+});


### PR DESCRIPTION
The spec does not limit the character length of `data uri src` values. But for practical purposes, all browsers implement their own limit for this attribute. There is no public documentation on the exact limits. All the resources available are investigative and maybe out of date.

This limit causes the bootcode to not be initialized properly.

The alternative is to use the `srcdoc` attribute. The `srcdoc` seems to have a higher limit(again, exact limits not available). The content can be passed as plain(escaped) text without encoding. That cuts down the content length as well.

Tested this with `postman-sandbox` on latest Chrome as well.