### PR TITLE
Fix the usage code by adding a missing backtick

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ uvm.createHost({
     bootTimeout: 30 * 1000, // default 30s. set `undefined` for Infinity
     bootCode: `bridge.on('ping', function () {
         bridge.send('pong', Date.now())
-    });'
+    });`
 }, function (err, bridge) {
 
     bridge.on('pong', console.log);


### PR DESCRIPTION
I've just noticed a little typo in the usage code (replacing a simple quote by a backtick) ;)