### PR TITLE
Create vm context with null as prototype

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - Fixed a bug where execution context was polluted with the global prototype
+
 1.7.6:
   date: 2019-08-01
   chores:

--- a/lib/uvm/bridge.js
+++ b/lib/uvm/bridge.js
@@ -53,7 +53,7 @@ var vm = require('vm'),
  */
 module.exports = function (emitter, options, callback) {
     var code = bridgeClientCode(options.bootCode),
-        context = options._sandbox || vm.createContext(),
+        context = options._sandbox || vm.createContext(Object.create(null)),
         bridgeDispatch;
 
     // inject console on debug mode

--- a/test/unit/secure-context.test.js
+++ b/test/unit/secure-context.test.js
@@ -1,0 +1,25 @@
+const uvm = require('../..');
+
+describe('secure context', function () {
+    it('should not be polluted with the global prototype', function (done) {
+        var context = uvm.spawn({
+            bootCode: `
+                bridge.on('execute', function (data) {
+                    bridge.dispatch('execute', {
+                        result: (function () {
+                            return this.constructor.constructor('return Object.keys(this)')();
+                        })()
+                    });
+                });
+            `
+        });
+
+        context.on('error', done);
+        context.on('execute', function (out) {
+            expect(out.result).to.be.an('array').that.does.not.include('process');
+            done();
+        });
+
+        context.dispatch('execute');
+    });
+});


### PR DESCRIPTION
Fixed a bug where execution context was polluted with the global prototype.