### PR TITLE
Use web workers for browser sandbox

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,7 @@
         "block-scoped-var": "error",
         "class-methods-use-this": "error",
         "complexity": "off",
-        "consistent-return": "warn",
+        "consistent-return": "off",
         "curly": "error",
         "default-case": "error",
         "dot-location": ["error", "property"],

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  new features:
+    - GH-407 Using Web Workers for browser sandbox
+
 1.7.9:
   date: 2020-07-13
   chores:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uvm [![Build Status](https://travis-ci.org/postmanlabs/uvm.svg?branch=develop)](https://travis-ci.org/postmanlabs/uvm) [![codecov](https://codecov.io/gh/postmanlabs/uvm/branch/develop/graph/badge.svg)](https://codecov.io/gh/postmanlabs/uvm)
 
-Module that exposes an event emitter to send data across contexts (vm in node and iframe in browser)
+Module that exposes an event emitter to send data across contexts ([VM](https://nodejs.org/api/vm.html) in Node.js and [Web Workers](https://www.w3.org/TR/workers/) in browser)
 
 ## Usage
 

--- a/firmware/sandbox-base.js
+++ b/firmware/sandbox-base.js
@@ -1,13 +1,10 @@
 module.exports = `
-<!DOCTYPE html><html><head><meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
-<meta charset="UTF-8"><script type="text/javascript">
-(function (win) {
+(function (self) {
     var init = function (e) {
-        win.removeEventListener('message', init);
+        self.removeEventListener('message', init);
         // eslint-disable-next-line no-eval
         (e && e.data && (typeof e.data.__init_uvm === 'string')) && eval(e.data.__init_uvm);
     };
-    win.addEventListener('message', init);
-}(window));
-</script>
-</head></html>`;
+    self.addEventListener('message', init);
+}(self));
+`;

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -27,6 +27,7 @@ var uuid = require('uuid'),
                         emit(e.data.__emit_uvm);
                 });
             }(__uvm_dispatch, "${id}"));
+            __uvm_emit('${Flatted.stringify(['load.' + id])}');
             __uvm_dispatch = null; __uvm_emit = null;
         `;
     };
@@ -34,6 +35,8 @@ var uuid = require('uuid'),
 module.exports = function (bridge, options, callback) {
     var id = uuid(),
         firmwareCode = sandboxFirmware(bridgeClientCode(options.bootCode), id),
+        firmwareObjectURL,
+        worker,
 
         // function to forward messages emitted
         forwardEmits = function (e) {
@@ -50,8 +53,21 @@ module.exports = function (bridge, options, callback) {
             bridge.emit(ERROR, e);
         },
 
-        firmwareObjectURL,
-        worker;
+        processCallback = function () {
+            bridge._dispatch = function () {
+                if (!worker) {
+                    return bridge.emit(ERROR,
+                        new Error('uvm: unable to dispatch "' + arguments[0] + '" post disconnection.'));
+                }
+
+                worker.postMessage({
+                    __emit_uvm: Flatted.stringify(Array.prototype.slice.call(arguments)),
+                    __id_uvm: id
+                });
+            };
+
+            callback(null, bridge);
+        };
 
     // if sandbox worker is provided, we simply need to init with firmware code
     // @todo validate sandbox type or APIs
@@ -69,22 +85,13 @@ module.exports = function (bridge, options, callback) {
         worker = new Worker(firmwareObjectURL);
     }
 
+    // on load attach the dispatcher
+    bridge.once('load.' + id, processCallback);
+
     // add event listener for receiving events from worker (is removed on disconnect)
     // don't set `onmessage` and `onerror` as it might override external sandbox
     worker.addEventListener(MESSAGE, forwardEmits);
     worker.addEventListener(ERROR, forwardErrors);
-
-    bridge._dispatch = function () {
-        if (!worker) {
-            return bridge.emit(ERROR,
-                new Error('uvm: unable to dispatch "' + arguments[0] + '" post disconnection.'));
-        }
-
-        worker.postMessage({
-            __emit_uvm: Flatted.stringify(Array.prototype.slice.call(arguments)),
-            __id_uvm: id
-        });
-    };
 
     // equip bridge to disconnect (i.e. terminate the worker)
     bridge._disconnect = function () {
@@ -108,6 +115,4 @@ module.exports = function (bridge, options, callback) {
 
     // help GC collect large variables
     firmwareCode = null;
-
-    callback(null, bridge);
 };

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -1,71 +1,43 @@
 /*
  * @note
- * options.bootTimeout is not implemented in browser sandbox. Reason is that as long as we use iFrame, there is no way
- * to interrupt an infinite loop.
+ * options.bootTimeout is not implemented in browser sandbox because there is no way to interrupt an infinite loop.
  */
-var _ = require('lodash'),
-    uuid = require('uuid'),
+var uuid = require('uuid'),
     Flatted = require('flatted'),
     MESSAGE = 'message',
-    LOAD = 'load',
     ERROR = 'error',
-    TARGET_ALL = '*',
-    SANDBOX_ELEMENT_TAG = 'iframe',
 
     // code for bridge
     bridgeClientCode = require('./bridge-client'),
 
     /**
-     * Default DOM attributes of sandbox
-     * @type {Object}
-     */
-    sandboxAttributes = {
-        'class': 'postman-uvm-context',
-        'style': 'display:none;',
-        'sandbox': 'allow-scripts'
-    },
-
-    /**
-     * Returns the HTML to be executed inside iFrame.
+     * Returns the firmware code to be executed inside Web Worker.
      *
      * @param {String} code
      * @param {String} id
-     * @param {Boolean} firmwareOnly
      * @return {String}
      */
-    sandboxCode = function (code, id, firmwareOnly) {
-        var firmware = `
-            __uvm_emit = function (args) {window.parent.postMessage({__id_uvm: "${id}",__emit_uvm: args}, "*");};
-
+    sandboxFirmware = function (code, id) {
+        return `
+            __uvm_emit = function (args) {self.postMessage({__id_uvm: "${id}",__emit_uvm: args});};
             try {${code}} catch (e) { setTimeout(function () { throw e; }, 0); }
-
             (function (emit, id) {
-                window.addEventListener("message", function (e) {
+                self.addEventListener("message", function (e) {
                     (e && e.data && (typeof e.data.__emit_uvm === 'string') && (e.data.__id_uvm === id)) &&
                         emit(e.data.__emit_uvm);
                 });
             }(__uvm_dispatch, "${id}"));
-            __uvm_emit('${Flatted.stringify(['load.' + id])}');
             __uvm_dispatch = null; __uvm_emit = null;
         `;
-
-        return firmwareOnly ? firmware : `<!DOCTYPE html><html><head>
-            <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"><meta charset="UTF-8">
-            <script type="text/javascript">${firmware}</script></head></html>`;
     };
 
 module.exports = function (bridge, options, callback) {
     var id = uuid(),
-        code = bridgeClientCode(options.bootCode),
-
-        // make sure we escape the code only once
-        serializedFirmware = unescape(encodeURIComponent(sandboxCode(code, id))),
-
-        iframe = options._sandbox || document.createElement(SANDBOX_ELEMENT_TAG),
+        firmwareCode = sandboxFirmware(bridgeClientCode(options.bootCode), id),
 
         // function to forward messages emitted
         forwardEmits = function (e) {
-            if (!(e && e.data && _.isString(e.data.__emit_uvm) && (e.data.__id_uvm === id))) { return; }
+            if (!(e && e.data && (typeof e.data.__emit_uvm === 'string') && (e.data.__id_uvm === id))) { return; }
 
             var args;
             try { args = Flatted.parse(e.data.__emit_uvm); }
@@ -73,70 +45,69 @@ module.exports = function (bridge, options, callback) {
             bridge.emit.apply(bridge, args); // eslint-disable-line prefer-spread
         },
 
-        processCallback = function () {
-            !options._sandbox && iframe.removeEventListener(LOAD, processCallback);
+        // function to forward errors emitted
+        forwardErrors = function (e) {
+            bridge.emit(ERROR, e);
+        },
 
-            bridge._dispatch = function () {
-                if (!iframe) {
-                    return bridge.emit(ERROR,
-                        new Error('uvm: unable to dispatch "' + arguments[0] + '" post disconnection.'));
-                }
+        firmwareObjectURL,
+        worker;
 
-                iframe.contentWindow.postMessage({
-                    __emit_uvm: Flatted.stringify(Array.prototype.slice.call(arguments)),
-                    __id_uvm: id
-                }, TARGET_ALL);
-            };
-
-            callback(null, bridge);
-        };
-
-    // add event listener for receiving events from iframe (is removed on disconnect)
-    window.addEventListener(MESSAGE, forwardEmits);
-
-    // equip bridge to disconnect (i.e. delete the iframe)
-    bridge._disconnect = function () {
-        if (!iframe) { return; }
-
-        // remove the message handler for this sandbox
-        window.removeEventListener(MESSAGE, forwardEmits);
-
-        // do not delete sandbox element if not created for the bridge
-        !options._sandbox && iframe.parentNode && iframe.parentNode.removeChild(iframe);
-        iframe = null;
-    };
-
-    // if sandbox element is provided, we simply need to init with firmware code and wait for load event to be fired
+    // if sandbox worker is provided, we simply need to init with firmware code
+    // @todo validate sandbox type or APIs
     if (options._sandbox) {
-        bridge.once('load.' + id, processCallback); // on load attach the dispatcher
+        worker = options._sandbox;
+        worker.postMessage({ __init_uvm: firmwareCode });
+    }
+    // else, spawn a new worker
+    else {
+        // convert the firmware code into a blob URL
+        firmwareObjectURL = window.URL.createObjectURL(
+            new Blob([firmwareCode], { type: 'text/javascript' })
+        );
 
-        iframe.contentWindow.postMessage({
-            __init_uvm: sandboxCode(code, id, true) // the last `true` param indicates firmwareOnly
-        }, TARGET_ALL);
-
-        return;
+        worker = new Worker(firmwareObjectURL);
     }
 
-    // this point onwards, it is our own iframe, so we do all the appending and other stuff to DOM
-    iframe.addEventListener(LOAD, processCallback); // removed right when executed
+    // add event listener for receiving events from worker (is removed on disconnect)
+    // don't set `onmessage` and `onerror` as it might override external sandbox
+    worker.addEventListener(MESSAGE, forwardEmits);
+    worker.addEventListener(ERROR, forwardErrors);
 
-    // prepare an iframe as context
-    _.forEach(sandboxAttributes, function (val, prop) {
-        iframe.setAttribute(prop, val);
-    });
+    bridge._dispatch = function () {
+        if (!worker) {
+            return bridge.emit(ERROR,
+                new Error('uvm: unable to dispatch "' + arguments[0] + '" post disconnection.'));
+        }
 
-    // add HTML and bootstrap code to the iframe
-    iframe.setAttribute('src', 'data:text/html;base64, ' + btoa(serializedFirmware));
+        worker.postMessage({
+            __emit_uvm: Flatted.stringify(Array.prototype.slice.call(arguments)),
+            __id_uvm: id
+        });
+    };
 
-    // data uri has size limits depending on the browsers
-    // in browsers that don't support srcdoc attribute the src attribute is accepted
-    // https://www.w3.org/TR/html5/semantics-embedded-content.html#an-iframe-srcdoc-document
-    iframe.setAttribute('srcdoc', serializedFirmware);
+    // equip bridge to disconnect (i.e. terminate the worker)
+    bridge._disconnect = function () {
+        if (!worker) { return; }
 
-    // now append the iframe to start processing stuff
-    document.body.appendChild(iframe);
+        // remove event listeners for this sandbox
+        worker.removeEventListener(MESSAGE, forwardEmits);
+        worker.removeEventListener(ERROR, forwardErrors);
+
+        // do not terminate sandbox worker if not spawned for the bridge
+        if (!options._sandbox) {
+            worker.terminate();
+
+            // revoke after termination. otherwise, blob reference is retained until GC
+            // refer: "chrome://blob-internals"
+            window.URL.revokeObjectURL(firmwareObjectURL);
+        }
+
+        worker = null;
+    };
 
     // help GC collect large variables
-    code = null;
-    serializedFirmware = null;
+    firmwareCode = null;
+
+    callback(null, bridge);
 };

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -33,6 +33,10 @@ var uuid = require('uuid'),
     };
 
 module.exports = function (bridge, options, callback) {
+    if (!(Blob && Worker && window && window.URL && window.URL.createObjectURL)) {
+        return callback(new Error('uvm: unable to setup communication bridge, missing required APIs'));
+    }
+
     var id = uuid(),
         firmwareCode = sandboxFirmware(bridgeClientCode(options.bootCode), id),
         firmwareObjectURL,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "uvm",
-  "version": "1.7.9",
+  "version": "1.8.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uvm",
-  "version": "1.7.9",
+  "version": "1.8.0-beta.1",
   "description": "Universal Virtual Machine for Node and Browser",
   "main": "index.js",
   "directories": {

--- a/test/unit/uvm-browser-missing-api.js
+++ b/test/unit/uvm-browser-missing-api.js
@@ -1,0 +1,20 @@
+(typeof window !== 'undefined' ? describe : describe.skip)('missing API in browser', function () {
+    var uvm = require('../../lib'),
+        originalWorker = window.Worker;
+
+    before(function () {
+        window.Worker = undefined;
+    });
+
+    after(function () {
+        window.Worker = originalWorker;
+    });
+
+    it('should connect a new context', function (done) {
+        uvm.spawn({}, function (err) {
+            expect(err).to.be.an('error').that.has.property('message',
+                'uvm: unable to setup communication bridge, missing required APIs');
+            done();
+        });
+    });
+});

--- a/test/unit/uvm-timeout.test.js
+++ b/test/unit/uvm-timeout.test.js
@@ -1,8 +1,8 @@
 ((typeof window === 'undefined') ? describe : describe.skip)('uvm timeout option', function () {
     var uvm = require('../../lib');
 
-    // options.bootTimeout is not implemented in browser sandbox. Reason is that as long as we use iFrame, there is no
-    // way to interrupt an infinite loop.
+    // options.bootTimeout is not implemented in browser sandbox because there
+    // is no way to interrupt an infinite loop.
     it('must exit if bootCode has infinite loop', function (done) {
         uvm.spawn({
             bootTimeout: 100,
@@ -20,8 +20,8 @@
         });
     });
 
-    // options.dispatchTimeout is not implemented in browser sandbox. Reason is that as long as we use iFrame, there is
-    // no way to interrupt an infinite loop.
+    // options.dispatchTimeout is not implemented in browser sandbox because
+    // there is no way to interrupt an infinite loop.
     it('must exit if dispatch is has infinite loop', function (done) {
         uvm.spawn({
             dispatchTimeout: 100,


### PR DESCRIPTION
Migrate from iFrame to Web Worker sandbox in the browser.
This internal change doesn't affect the external API.

## Benchmark
**iFrame**
```
no object communication x 3,809 ops/sec ±1.54% (66 runs sampled)
flat object communication x 3,279 ops/sec ±1.32% (61 runs sampled)
one level nested object communication x 3,523 ops/sec ±1.52% (65 runs sampled)
two levels nested object communication x 3,557 ops/sec ±1.28% (68 runs sampled)
full nested object communication x 3,543 ops/sec ±1.18% (66 runs sampled)
recursive nested object communication x 3,576 ops/sec ±2.22% (65 runs sampled)
```

**Web Workers**
```
no object communication x 3,612 ops/sec ±3.04% (61 runs sampled)
flat object communication x 3,486 ops/sec ±1.77% (65 runs sampled)
one level nested object communication x 3,249 ops/sec ±1.94% (58 runs sampled)
two levels nested object communication x 3,139 ops/sec ±1.46% (55 runs sampled)
full nested object communication x 3,522 ops/sec ±0.95% (67 runs sampled)
recursive nested object communication x 3,644 ops/sec ±2.29% (68 runs sampled)
```