### PR TITLE
Deleted __uvm_* private variables from the global scope

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,7 @@
 master:
   new features:
     - GH-407 Using Web Workers for browser sandbox
+    - GH-410 Deleted __uvm_* private variables from the global scope
 
 1.7.9:
   date: 2020-07-13

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -18,17 +18,22 @@ var uuid = require('uuid'),
      * @return {String}
      */
     sandboxFirmware = function (code, id) {
+        // @note self.postMessage and self.addEventListener methods are cached
+        // in variable or closure because bootCode might mutate the global scope
         return `
-            __uvm_emit = function (args) {self.postMessage({__id_uvm: "${id}",__emit_uvm: args});};
+            __uvm_emit = function (postMessage, args) {
+                postMessage({__id_uvm: "${id}",__emit_uvm: args});
+            }.bind(null, self.postMessage);
+            __uvm_addEventListener = self.addEventListener;
             try {${code}} catch (e) { setTimeout(function () { throw e; }, 0); }
             (function (emit, id) {
-                self.addEventListener("message", function (e) {
+                __uvm_addEventListener("message", function (e) {
                     (e && e.data && (typeof e.data.__emit_uvm === 'string') && (e.data.__id_uvm === id)) &&
                         emit(e.data.__emit_uvm);
                 });
             }(__uvm_dispatch, "${id}"));
             __uvm_emit('${Flatted.stringify(['load.' + id])}');
-            __uvm_dispatch = null; __uvm_emit = null;
+            __uvm_dispatch = null; __uvm_emit = null; __uvm_addEventListener = null;
         `;
     };
 

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -33,7 +33,7 @@ var uuid = require('uuid'),
                 });
             }(__uvm_dispatch, "${id}"));
             __uvm_emit('${Flatted.stringify(['load.' + id])}');
-            __uvm_dispatch = undefined; __uvm_emit = undefined; __uvm_addEventListener = undefined;
+            __uvm_dispatch = null; __uvm_emit = null; __uvm_addEventListener = null;
             delete __uvm_dispatch; delete __uvm_emit; delete __uvm_addEventListener;
         `;
     };

--- a/lib/uvm/bridge.browser.js
+++ b/lib/uvm/bridge.browser.js
@@ -33,7 +33,8 @@ var uuid = require('uuid'),
                 });
             }(__uvm_dispatch, "${id}"));
             __uvm_emit('${Flatted.stringify(['load.' + id])}');
-            __uvm_dispatch = null; __uvm_emit = null; __uvm_addEventListener = null;
+            __uvm_dispatch = undefined; __uvm_emit = undefined; __uvm_addEventListener = undefined;
+            delete __uvm_dispatch; delete __uvm_emit; delete __uvm_addEventListener;
         `;
     };
 

--- a/lib/uvm/bridge.js
+++ b/lib/uvm/bridge.js
@@ -89,7 +89,7 @@ module.exports = function (emitter, options, callback) {
     }
     finally { // set all raw interface methods to null (except the dispatcher since we need it later)
         vm.runInContext(`
-            __uvm_emit = undefined; delete __uvm_emit; __uvm_dispatch = undefined; delete __uvm_dispatch;
+            __uvm_emit = null; delete __uvm_emit; __uvm_dispatch = null; delete __uvm_dispatch;
         `, context);
         delete context.__uvm_emit;
         delete context.__uvm_dispatch;
@@ -114,8 +114,8 @@ module.exports = function (emitter, options, callback) {
             // restore the dispatcher for immediate use!
             vm.runInContext(`
                 (function (dispatch, data) {
-                    ${id} = undefined; (delete ${id});
-                    ${dispatchId} = undefined; (delete ${dispatchId});
+                    ${id} = null; (delete ${id});
+                    ${dispatchId} = null; (delete ${dispatchId});
                     dispatch(String(data));
                 }(${dispatchId}, ${id}));
             `, context, {

--- a/lib/uvm/bridge.js
+++ b/lib/uvm/bridge.js
@@ -114,8 +114,8 @@ module.exports = function (emitter, options, callback) {
             // restore the dispatcher for immediate use!
             vm.runInContext(`
                 (function (dispatch, data) {
-                    ${id} = null; (delete ${id});
-                    ${dispatchId} = null; (delete ${dispatchId});
+                    ${id} = undefined; (delete ${id});
+                    ${dispatchId} = undefined; (delete ${dispatchId});
                     dispatch(String(data));
                 }(${dispatchId}, ${id}));
             `, context, {

--- a/lib/uvm/bridge.js
+++ b/lib/uvm/bridge.js
@@ -88,7 +88,9 @@ module.exports = function (emitter, options, callback) {
         return callback(err);
     }
     finally { // set all raw interface methods to null (except the dispatcher since we need it later)
-        vm.runInContext('__uvm_emit = null; __uvm_dispatch = null;', context);
+        vm.runInContext(`
+            __uvm_emit = undefined; delete __uvm_emit; __uvm_dispatch = undefined; delete __uvm_dispatch;
+        `, context);
         delete context.__uvm_emit;
         delete context.__uvm_dispatch;
     }

--- a/test/unit/uvm-browser-mutate-scope.test copy.js
+++ b/test/unit/uvm-browser-mutate-scope.test copy.js
@@ -1,0 +1,43 @@
+(typeof window !== 'undefined' ? describe : describe.skip)('custom sandbox in browser', function () {
+    var uvm = require('../../lib'),
+        firmware = require('../../firmware/sandbox-base'),
+        firmwareUrl,
+        worker;
+
+    beforeEach(function () {
+        firmwareUrl = window.URL.createObjectURL(
+            new Blob([firmware], { type: 'text/javascript' })
+        );
+        worker = new Worker(firmwareUrl);
+    });
+
+    afterEach(function () {
+        worker.terminate();
+        window.URL.revokeObjectURL(firmwareUrl);
+        worker = firmwareUrl = null;
+    });
+
+    it('should cache the required methods and not depend on the global scope', function (done) {
+        uvm.spawn({
+            _sandbox: worker,
+            bootCode: `
+                // mutate the global scope
+                self.postMessage = function noop () {};
+                self.addEventListener = function noop () {};
+
+                bridge.on('loopback', function (data) {
+                    bridge.dispatch('loopback', data);
+                });
+            `
+        }, function (err, context) {
+            if (err) { return done(err); }
+
+            context.on('loopback', function (data) {
+                expect(data).to.equal('this should return');
+                done();
+            });
+            context.dispatch('loopback', 'this should return');
+        });
+
+    });
+});

--- a/test/unit/uvm-sanity.test.js
+++ b/test/unit/uvm-sanity.test.js
@@ -114,10 +114,10 @@ describe('uvm', function () {
                     expect(data).to.be.an('object');
 
                     // In Node.js v6 VM, `delete global` doesn't work so we make
-                    // sure it's set to undefined.
+                    // sure it's set to null.
                     if (nodeVersion === 6) {
                         for (var prop in data) { // eslint-disable-line guard-for-in
-                            expect(data[prop]).to.equal('undefined');
+                            expect(data[prop]).to.equal('null');
                         }
                         return done();
                     }

--- a/test/unit/uvm-sanity.test.js
+++ b/test/unit/uvm-sanity.test.js
@@ -89,20 +89,48 @@ describe('uvm', function () {
             uvm.spawn({
                 bootCode: `
                     bridge.on('getProps', function () {
-                        bridge.dispatch('getProps', Object.getOwnPropertyNames(Function('return this')()));
+                        var globalContext = Function('return this')(),
+                            data = {};
+
+                        Object.getOwnPropertyNames(globalContext).forEach(function (prop) {
+                            if (prop.indexOf('__uvm') !== -1) {
+                                data[prop] = String(globalContext[prop]);
+                            }
+                        });
+
+                        bridge.dispatch('getProps', data);
+
+                        // Use this when we drop support for Node v6
+                        // bridge.dispatch('getProps', Object.getOwnPropertyNames(Function('return this')()));
                     });
                 `
             }, function (err, context) {
                 expect(err).to.be.null;
 
+                var nodeVersion = process && process.versions && parseInt(process.versions.node);
+
                 context.on('error', done);
                 context.on('getProps', function (data) {
-                    expect(data).to.be.an('array').that.is.not.empty;
+                    expect(data).to.be.an('object');
 
-                    for (var key of data) {
-                        expect(key).to.not.have.string('__uvm');
+                    // In Node.js v6 VM, `delete global` doesn't work so we make
+                    // sure it's set to undefined.
+                    if (nodeVersion === 6) {
+                        for (var prop in data) { // eslint-disable-line guard-for-in
+                            expect(data[prop]).to.equal('undefined');
+                        }
+                        return done();
                     }
+
+                    expect(data).to.be.empty;
                     done();
+
+                    // Use this when we drop support for Node v6
+                    // expect(data).to.be.an('array').that.is.not.empty;
+
+                    // for (var key of data) {
+                    //     expect(key).to.not.have.string('__uvm');
+                    // }
                 });
 
                 context.dispatch('getProps');


### PR DESCRIPTION
Make sure we don't depend on the global scope methods as well as don't pollute it as well by:
* Cleaning up the `__uvm_*` private variables from the global scope
* Caching the dependent global methods before executing the `bootCode`