### PR TITLE
Switch to node style listener to avoid using undici's (node dep) MessageEvent class

### DIFF
--- a/lib/bridge.js
+++ b/lib/bridge.js
@@ -27,20 +27,20 @@ const Flatted = require('flatted'),
         __uvm_emit = function (postMessage, args) {
             postMessage({__id_uvm: "${id}", __emit_uvm: args});
         }.bind(null, __self.postMessage.bind(__self));
-        __uvm_addEventListener = __self.addEventListener.bind(__self);
+        __uvm_on = __self.on.bind(__self);
 
         ${bridgeClientCode()}
 
         (function (emit, id) {
-            __uvm_addEventListener("message", function (e) {
-                const { __emit_uvm, __id_uvm } = e?.data || e || {};
+           __uvm_on("message", function (e) {
+                const { __emit_uvm, __id_uvm } = e || {};
                 if (typeof __emit_uvm === 'string' && __id_uvm === id) {
                     emit(__emit_uvm);
                 }
             });
         }(__uvm_dispatch, "${id}"));
         __uvm_dispatch = null; delete __uvm_dispatch;
-        __uvm_addEventListener = null; delete __uvm_addEventListener;
+        __uvm_on = null; delete __uvm_on;
 
         (function (self, bridge, setTimeout) {
             ${Worker.__exceptionHandler}

--- a/lib/worker.browser.js
+++ b/lib/worker.browser.js
@@ -32,7 +32,14 @@ class WebWorker {
         callback && callback();
     }
 
-    static __self = 'self';
+    static __self = `(function () {
+        self.on = function (name, listener) {
+            return self.addEventListener(name, function (e) {
+                listener(e.data);
+            });
+        };
+        return self;
+    }())`;
 
     static __exceptionHandler = `
     ((close) => {


### PR DESCRIPTION
## Issue
In Node v22.3.0, Node's MessageEvent was replaced with undici's (https://github.com/nodejs/node/pull/52370). MessageEvent is [loaded lazily](https://github.com/nodejs/node/pull/52370/files#diff-cbe9ed0255d58a51cf6442116da17f833c9d57c6244dc1efa74760d1c91860e7R92) and requires globalThis and global during initialization. If a consumer of UVM mutates the global scope in bootCode before the MessageEvent gets loaded, it can lead to a less stable system.

## Fix
Right now `bridge.js` relies on `parentPort.addEventListener` for node environment to keep the interface consistent with web workers. The ` addEventListener` registers a listener that gets fired with MessageEvent's instance as an argument. This is now replaced with `parentPort.on`, which registers a node-style listener, i.e., listener gets called directly with `data` received, and usage of MessageEvent class is avoided.

`worker.browser.js` is also updated to expose `on` method for consistency.

 